### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-documentation=true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,5 +37,5 @@ Suggests:
     reshape2,
     gplots
 VignetteBuilder: knitr
-URL: https://sebastiz.github.io/EndoMineR/index.html
-BugReports: https://github.com/sebastiz/EndoMineR/issues
+URL: https://sebastiz.github.io/EndoMineR/index.html, https://github.com/ropensci/EndoMineR
+BugReports: https://github.com/ropensci/EndoMineR/issues


### PR DESCRIPTION
Suggesting this because GitHub linguist currently classifies this repo as html (https://github.com/github/linguist#overrides )